### PR TITLE
fix: downloads all reports generated on a specific day

### DIFF
--- a/src/Services/EnturSales.php
+++ b/src/Services/EnturSales.php
@@ -47,12 +47,10 @@ class EnturSales
             'authorization' => 'Bearer ' . EnturCleosApi::getApiToken()
         ]);
 
-        $continueProcessing = true;
-
         $archive = null;
 
         $datasetId = $this->fetchNextDataSetId($client, $chunkId, 0);
-        while ($datasetId !== null && $continueProcessing) {
+        while ($datasetId !== null) {
             $this->debug("Processing dataset ID: %s, chunkId: %s", $datasetId, $chunkId);
             $chunkDate = Carbon::parse($chunkId)->format("Ymd");
 
@@ -86,7 +84,7 @@ class EnturSales
 
                 $archive->addFromString($report->reportName, $reportContent);
             } else {
-                $continueProcessing = false;
+                break;
             }
 
             $datasetId = $this->fetchNextDataSetId($client, $chunkId, $datasetId);


### PR DESCRIPTION
End of month (and banking holidays) won't generate all the reports until first real working day.
This pull request now downloads all reports generated by (orderBy) CLEOS for any given chunkId

orderDate: date report is generated - can be multiple reports
orderBy: the process/user/entity that placed the order to generate report

Still using the parquet file, since going for BigQuery seems to be a large task to complete