### PR TITLE
fix: make columns nullable to fix import-error 2025-03-04

### DIFF
--- a/database/migrations/2025_10_30_100000_update_ragnarok_entur_product_sales_table.php
+++ b/database/migrations/2025_10_30_100000_update_ragnarok_entur_product_sales_table.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // Drop existing composite primary key
+        Schema::table('entur_product_sales', function (Blueprint $table) {
+            $table->dropPrimary(['group_id', 'sales_orderline_id', 'sales_fare_product_id']);
+        });
+
+        // Add new auto-incrementing primary key
+        Schema::table('entur_product_sales', function (Blueprint $table) {
+            $table->increments('id')->first();
+        });
+
+        // Modify columns to be nullable
+        Schema::table('entur_product_sales', function (Blueprint $table) {
+            $table->uuid('sales_fare_product_id')->nullable()->change();
+            $table->uuid('sales_orderline_id')->nullable()->change();
+            $table->string('sales_package_name')->nullable()->change();
+            $table->string('sales_package_ref')->nullable()->change();
+            $table->string('sales_payment_type')->nullable()->change();
+            $table->dateTime('sales_start_time')->nullable()->change();
+            $table->string('sales_user_profile_name')->nullable()->change();
+            $table->string('sales_user_profile_ref')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('entur_product_sales', function (Blueprint $table) {
+            $table->dropColumn('id');
+        });
+
+        Schema::table('entur_product_sales', function (Blueprint $table) {
+            $table->uuid('sales_fare_product_id')->nullable(false)->change();
+            $table->uuid('sales_orderline_id')->nullable(false)->change();
+            $table->string('sales_package_name')->nullable(false)->change();
+            $table->string('sales_package_ref')->nullable(false)->change();
+            $table->string('sales_payment_type')->nullable(false)->change();
+            $table->dateTime('sales_start_time')->nullable(false)->change();
+            $table->string('sales_user_profile_name')->nullable(false)->change();
+            $table->string('sales_user_profile_ref')->nullable(false)->change();
+        });
+
+        Schema::table('entur_product_sales', function (Blueprint $table) {
+            $table->primary(['group_id', 'sales_orderline_id', 'sales_fare_product_id']);
+        });
+    }
+};

--- a/database/migrations/2025_10_30_100000_update_ragnarok_entur_product_sales_table.php
+++ b/database/migrations/2025_10_30_100000_update_ragnarok_entur_product_sales_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        // Drop existing composite primary key
+        // Drop existing compound primary key
         Schema::table('entur_product_sales', function (Blueprint $table) {
             $table->dropPrimary(['group_id', 'sales_orderline_id', 'sales_fare_product_id']);
         });


### PR DESCRIPTION
On row (only row on `chunkId: 2025-03-04`) fails to import because of missing sales product data.

To fix this the compound primary key is removed. A new auto increment primary key called ID is added, and all affected columns gets set to nullable in the database.

Empty columns in CSV, and their database mapping:

```
FARE_PRODUCT_ID         =>   sales_fare_product_id
ORDERLINE_ID            =>   sales_orderline_id
SALES_PACKAGE_NAME      =>   sales_package_name
SALES_PACKAGE_REF       =>   sales_package_ref
PAYMENT_TYPE            =>   sales_payment_type
JOURNEY_START_TIME      =>   sales_start_time
USER_PROFILE_NAME       =>   sales_user_profile_name
USER_PROFILE_REF        =>   sales_user_profile_ref
```