### PR TITLE
fix: adds nullable to local tax rate and code

### DIFF
--- a/database/migrations/2025_11_26_092534_update_nullable_fields.php
+++ b/database/migrations/2025_11_26_092534_update_nullable_fields.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('entur_product_sales', function (Blueprint $table) {
+            $table->integer('line_local_tax_code')->nullable()->change();
+            $table->integer('line_local_tax_rate')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
Ragnrarok entur-sales import has failed again. A few more fields that obviously have to be nullable in the database.

"Barn 0-5 år - gratis" seems to be the culprit. It has no ACCT_LOCAL_TAX_CODE or ACCT_LOCAL_TAX_RATE in the downloaded data.

This pr adds nullable to the fields in the database (do we even need those fields?)
